### PR TITLE
Use custom Nginx config

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,8 @@ ARG IMAGE=nginx:1.27-alpine-slim
 ARG APP_USER=root
 ARG BUILD_HOME=/app
 ARG BUILD_OUT=dist
-ARG APP_HOME=/usr/share/nginx/html
+ARG APP_HOME=${BUILD_HOME}
+ARG NGINX_TEMPLATE=docker/default.conf.template
 ARG VITE_CODEX_API_URL=${VITE_CODEX_API_URL:-http://127.0.0.1:8080}
 ARG VITE_GEO_IP_URL=${VITE_GEO_IP_URL:-http://127.0.0.1:8080}
 
@@ -31,8 +32,13 @@ ARG APP_USER
 ARG BUILD_HOME
 ARG BUILD_OUT
 ARG APP_HOME
+ARG NGINX_TEMPLATE
 
 WORKDIR ${APP_HOME}
+RUN mkdir /etc/nginx/templates
+COPY ${NGINX_TEMPLATE} /etc/nginx/templates
 COPY --chown=${APP_USER}:${APP_USER} --from=builder ${BUILD_HOME}/${BUILD_OUT} .
+
+ENV APP_HOME=${APP_HOME}
 
 EXPOSE 80

--- a/docker/default.conf.template
+++ b/docker/default.conf.template
@@ -1,0 +1,15 @@
+server {
+    listen       80;
+    server_name  localhost;
+
+    root  /usr/share/nginx/html;
+
+    error_page  500 502 503 504  /50x.html;
+
+    location / {
+        root   ${APP_HOME};
+        index  index.html;
+
+        try_files  $uri  $uri/  /index.html  =404;
+    }
+}


### PR DESCRIPTION
To make Nginx working correctly with SPA it is required to update it's config file.

The easiest way is to pass a custom config - main `nginx.conf` or even a `conf.d/default.conf`.

We did select to use a custom `default.conf` with [templating](https://hub.docker.com/_/nginx). In that way we can pass Dockerfile `APP_HOME` variable to the Nginx config.

We can test a build from this PR branch
```shell
docker run \
  --rm \
  -p 3000:80 \
  codexstorage/codex-marketplace-ui:sha-948fcc5
```

http://localhost:3000

Closes #53 