### PR TITLE
Update Docker examples

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -54,6 +54,5 @@
    --name codex-marketplace-ui \
    --net=host \
    -e 'APP_PORT=3000' \
-   -p 3000:3000 \
    codexstorage/codex-marketplace-ui:latest
  ```


### PR DESCRIPTION
PR updates Docker examples - when we are running with the `--net=host`, port publishing is not used.